### PR TITLE
re-usable metadata templater 

### DIFF
--- a/data_release/metadata_create_timeseries.R
+++ b/data_release/metadata_create_timeseries.R
@@ -1,0 +1,75 @@
+library(magrittr)
+library(xml2)
+
+
+m <- xml_new_document() %>%
+  xml_add_child("metadata") %>%
+  xml_add_child("idinfo")
+
+m %>%  xml_add_child("citation") %>%
+  xml_add_child("citeinfo") %>%
+  xml_add_child("origin", "{{authors}}") %>%
+  xml_add_sibling('pubdate', "{{pubdate}}") %>%
+  xml_add_sibling('title', "{{title}}") %>%
+  xml_add_sibling('geoform', "text files") %>%
+  xml_add_sibling('onlink', "{{doi}}")
+
+m %>%
+  xml_add_child('descript') %>%
+  xml_add_child("abstract",'{{abstract}}') %>%
+  xml_add_sibling("purpose", '{{purpose}}')
+
+m %>%
+  xml_add_child('timeperd') %>%
+  xml_add_child("timeinfo") %>%
+  xml_add_child("rngdates") %>%
+  xml_add_child('begdate','{{start-date}}') %>%
+  xml_add_sibling('enddate','{{end-date}}')
+m %>%
+  xml_add_child('status') %>%
+  xml_add_child("progress", "Complete") %>% 
+  xml_add_sibling('update','{{update}}') 
+
+m %>% 
+  xml_add_child('spdom') %>% 
+  xml_add_child('bounding') %>% 
+  xml_add_child('westbc', "{{wbbox}}") %>% 
+  xml_add_sibling('eastbc', "{{ebbox}}") %>% 
+  xml_add_sibling('northbc', "{{nbbox}}") %>% 
+  xml_add_sibling('southbc', "{{sbbox}}")
+
+k <- xml_add_child(m, 'keywords') 
+
+k %>% 
+  xml_add_child('theme', "\n<themekt>none</themekt>\n{{#themekeywords}}<themekey>{{.}}</themekey>\n{{/themekeywords}}")
+
+k %>% 
+  xml_add_child('theme') %>% 
+  xml_add_child('themekt','ISO 19115 Topic Category') %>% 
+  xml_add_sibling('themekey','environment') %>% 
+  xml_add_sibling('themekey','inlandWaters') %>% 
+  xml_add_sibling('themekey','007') %>% 
+  xml_add_sibling('themekey','012') 
+
+m %>% 
+  xml_add_child('place') %>% 
+  xml_add_child('placekt','Department of Commerce, 1995, Countries, Dependencies, Areas of Special Sovereignty, and 
+                Their Principal Administrative Divisions,  Federal Information Processing Standard (FIPS) 10-4, 
+                Washington, D.C., National Institute of Standards and Technology') %>% 
+  xml_add_sibling('placekey','United States') %>% 
+  xml_add_sibling('placekey','US')
+m %>% 
+  xml_add_child('place', "\n{{#states}}<placekt>U.S. Department of Commerce, 1987, Codes for the identification of the States, 
+                the District of Columbia and the outlying areas of the United States, and associated areas 
+                (Federal Information Processing Standard 5-2): Washington, D. C., NIST</placekt>
+                <placekey>{{.}}</placekey>\n{{/states}}")
+  
+  
+  
+write_xml(m, file = 'test.xml')
+
+suppressWarnings(readLines('test.xml')) %>% 
+  gsub(pattern = '&gt;',replacement = '>',.) %>% 
+  gsub(pattern = '&lt;',replacement = '<',.) %>% 
+  cat(file = 'test.xml', sep = '\n')
+ 


### PR DESCRIPTION
@aappling-usgs this is a WIP (only part way through the required metadata) but the intent is to create a template that can be filled in by `whisker` and result in the complete xml. 

The result creates this:

```XML
<?xml version="1.0"?>
<metadata>
  <idinfo>
    <citation>
      <citeinfo>
        <origin>{{authors}}</origin>
        <pubdate>{{pubdate}}</pubdate>
        <title>{{title}}</title>
        <geoform>text files</geoform>
        <onlink>{{doi}}</onlink>
      </citeinfo>
    </citation>
    <descript>
      <abstract>{{abstract}}</abstract>
      <purpose>{{purpose}}</purpose>
    </descript>
    <timeperd>
      <timeinfo>
        <rngdates>
          <begdate>{{start-date}}</begdate>
          <enddate>{{end-date}}</enddate>
        </rngdates>
      </timeinfo>
    </timeperd>
    <status>
      <progress>Complete</progress>
      <update>{{update}}</update>
    </status>
    <spdom>
      <bounding>
        <westbc>{{wbbox}}</westbc>
        <eastbc>{{ebbox}}</eastbc>
        <northbc>{{nbbox}}</northbc>
        <southbc>{{sbbox}}</southbc>
      </bounding>
    </spdom>
    <keywords>
      <theme>
<themekt>none</themekt>
{{#themekeywords}}<themekey>{{.}}</themekey>
{{/themekeywords}}</theme>
      <theme>
        <themekt>ISO 19115 Topic Category</themekt>
        <themekey>environment</themekey>
        <themekey>inlandWaters</themekey>
        <themekey>007</themekey>
        <themekey>012</themekey>
      </theme>
    </keywords>
    <place>
      <placekt>Department of Commerce, 1995, Countries, Dependencies, Areas of Special Sovereignty, and 
                Their Principal Administrative Divisions,  Federal Information Processing Standard (FIPS) 10-4, 
                Washington, D.C., National Institute of Standards and Technology</placekt>
      <placekey>United States</placekey>
      <placekey>US</placekey>
    </place>
    <place>
{{#states}}<placekt>U.S. Department of Commerce, 1987, Codes for the identification of the States, 
                the District of Columbia and the outlying areas of the United States, and associated areas 
                (Federal Information Processing Standard 5-2): Washington, D. C., NIST</placekt>
                <placekey>{{.}}</placekey>
{{/states}}</place>
  </idinfo>
</metadata>
```

and the `#states` and `#themekeywords` is supposed to loop through the state and themekeyword vectors to create multiple sections for those. a la:

```r
states <- c('WI','NH','NC')
template = '<place>
{{#states}}<placekt>U.S. Department of Commerce, 1987, Codes for the identification of the States, 
     the District of Columbia and the outlying areas of the United States, and associated areas 
    (Federal Information Processing Standard 5-2): Washington, D. C., NIST</placekt>
       <placekey>{{.}}</placekey>
        {{/states}}</place>'
whisker.render(template)
```
```XML
<place>
   <placekt>U.S. Department of Commerce, 1987, Codes for the identification of the States, \n    the District of Columbia and the outlying areas of the United States, and associated areas \n    (Federal Information Processing Standard 5-2): Washington, D. C., NIST</placekt>
   <placekey>WI</placekey>
   <placekt>U.S. Department of Commerce, 1987, Codes for the identification of the States, \n    the District of Columbia and the outlying areas of the United States, and associated areas \n    (Federal Information Processing Standard 5-2): Washington, D. C., NIST</placekt>\n        <placekey>NH</placekey>\n        <placekt>U.S. Department of Commerce, 1987, Codes for the identification of the States, \n    the District of Columbia and the outlying areas of the United States, and associated areas \n    (Federal Information Processing Standard 5-2): Washington, D. C., NIST</placekt>\n        <placekey>NC</placekey>\n        </place>
```
☝️ oh, I guess that isn't quite working right, but you get the point
