### PR TITLE
only try invalid tses once

### DIFF
--- a/1_timeseries/code/stage_ts.R
+++ b/1_timeseries/code/stage_ts.R
@@ -63,7 +63,7 @@ stage_ts <- function(ts.file, config=yaml.load_file("../1_timeseries/in/ts_confi
                 }, warning=function(w) {
                   if(grepl("NWIS error", w$message)) message(w$message)
                 }, message=function(m) {
-                  if(grepl("(data are unavailable)|(no non-NA data)", m$message)) {
+                  if(grepl("(verify_ts)|(data are unavailable)|(no non-NA data)", m$message)) {
                     no_data <<- c(no_data, to.stage$filepath[i])
                   }            
                 })


### PR DESCRIPTION
@jread-usgs does this work for the bad NWIS tses you're dealing with (those with duplicate dates)?