### PR TITLE
Task remake

### DIFF
--- a/4_data_release/code/model_release_tasks.R
+++ b/4_data_release/code/model_release_tasks.R
@@ -1,0 +1,69 @@
+create_model_release_task_plan <- function(metab.config) {
+  
+  # define the tasks as unique IDs for each model
+  model_titles <- make_metab_run_title(
+    format(as.Date(metab.config$date), '%y%m%d'), metab.config$tag, metab.config$strategy)
+  model_names <- make_metab_model_name(
+    model_titles, metab.config$config.row, metab.config$site)
+  
+  # define variables to be used by several steps or functions
+  model_folder <- '../4_data_release/cache/models'
+  download_paths <- mda.streams::make_metab_model_path(
+    model_name=model_names, folder=model_folder) %>%
+    setNames(model_names)
+  
+  if(!dir.exists(model_folder)) dir.create(model_folder)
+  download <- create_task_step(
+    step_name = 'download',
+    target = function(task_name, step_name, ...) {
+      sprintf("'%s'", download_paths[[task_name]])
+    },
+    command = function(task_name, ...) {
+      sprintf(
+        "download_model(model_name=I('%s'), folder=I('%s'), version=I('original'))",
+        download_paths[[task_name]], model_folder)
+    }
+  )
+  inputs <- create_task_step(
+    step_name = 'inputs',
+    target = function(task_name, step_name, ...) {
+      sprintf("'%s/%s.%s.rds'", model_folder, step_name, task_name)
+    },
+    command = function(task_name, ...) {
+      sprintf("extract_model_inputs('%s', target_name)", download_paths[[task_name]])
+    }
+  )
+  # dailies <- create_task_step(
+  #   step_name = 'dailies',
+  #   target = target_fun
+  # )
+  # fits <- create_task_step(
+  #   step_name = 'fits',
+  #   target = target_fun
+  # )
+  # diagnostics <- create_task_step(
+  #   step_name = 'diagnostics',
+  #   target = target_fun
+  # )
+  
+  task_plan <- create_task_plan(model_names, list(download, inputs))
+}
+
+create_model_release_makefile <- function(makefile, task_plan) {
+  create_task_makefile(
+    makefile=makefile, task_plan=task_plan,
+    job_target = 'model_release', include = '4_release_models.yml',
+    packages=c('mda.streams', 'streamMetabolizer', 'dplyr'),
+    file_extensions=c('RData'))
+}
+
+download_model <- function(model_name, folder, version) {
+  mda.streams::login_sb()
+  download_metab_model(model_name=model_name, folder=folder, version=version)
+}
+
+extract_model_inputs <- function(mm_path, inputs_path) {
+  path_vars <- load(mm_path)
+  dat <- get_data(mm)
+  write.table(dat, file=inputs_path, sep='\n', row.names=FALSE)
+}

--- a/lib/create_task_makefile.R
+++ b/lib/create_task_makefile.R
@@ -1,0 +1,142 @@
+#' Create a templated remake YAML file that organizes tasks and their sub-tasks
+#' for a large number of targets
+#'
+#' This function is a first draft of the scipiper function. Let's see how it
+#' goes.
+#'
+#' @param makefile
+#' @param include
+#' @param packages
+#' @param sources
+#' @param job_target single character string naming the default target, which
+#'   will include all tasks within the job
+#' @param coordinates character vector of work coordinates, with length equal to
+#'   the number of tasks. These character strings will be used to prefix all
+#'   steps within a task. The prefix for each task should describe the aspect[s]
+#'   of a task that position it within the larger parameter space of work to be
+#'   done. Examples: site IDs, model names, character code describing specific
+#'   parameterization of model
+#' @param targets
+#' @param depends
+#' @param command
+#' @param ...
+#' @examples 
+#' steps <- list(
+#'   step1 = list(
+#'     target = function(task_name, step_name, ...) {
+#'       sprintf('%s_%s', task_name, step_name)
+#'     },
+#'     depends = c('A','B'),
+#'     command = 'process(target_name)'
+#'   ),
+#'   step2 = list(
+#'     command = function(target, ...) {
+#'       sprintf('visualize(%s)', target)
+#'     }
+#'   )
+#' )
+#' task_plan <- create_task_plan(c('AZ','CA','CO'), .steps=steps)
+step_defaults <- list(
+  target = function(task_name, step_name, ...) {
+    sprintf('%s_%s', task_name, step_name)
+  },
+  depends = character(0),
+  command = function(step_name, ...) {
+    sprintf('%s(target_name)', step_name)
+  }
+)
+create_task_plan <- function(coordinates, ..., .steps, step_defaults=step_defaults) {
+  
+  # the steps definitions (steps_defs) can be passed in as [named] ... lists or
+  # in a big list named .steps
+  dotsteps <- list(...)
+  steps_defs <- if(missing(.steps)) {
+    dotsteps
+  } else if(length(dotsteps) > 0) {
+    stop("don't define both ... and .steps")
+  } else {
+    .steps
+  }
+  
+  # munge the coordinates into a named list
+  coordinates <- if(is.data.frame(coordinates)) {
+    whisker::rowSplit(coordinates)
+  } else if(is.list(coordinates)) {
+    coordinates
+  } else if(is.character(coordinates)) {
+    setNames(as.list(rep(NA, length(coordinates))), coordinates)
+  }
+  
+  # prepare a list of the tasks and steps
+  tasks <- list()
+  seq_coords <- seq_along(coordinates)
+  seq_steps <- seq_along(steps_defs)
+  for(i in seq_coords) {
+    task <- list(
+      task_name = names(coordinates)[i],
+      steps = list()
+    )
+    for(j in seq_steps) {
+      # isolate just the definitions for this step
+      step_def <- steps_defs[[j]]
+      
+      # every step is a list with step_name as the first element
+      step <- list()
+      step$step_name = names(steps_defs)[[j]]
+      
+      # use the user's step definitions to define the recipe
+      step$target <- evaluate_step_element(step_def$target, step_defaults$target, task, step)
+      step$depends <- evaluate_step_element(step_def$depends, step_defaults$depends, task, step)
+      step$command <- evaluate_step_element(step_def$command, step_defaults$command, task, step)
+      
+      # add a T/F to help whisker avoid empty depends blocks
+      step$has_depends <- length(step$depends) > 0
+      
+      # add this step to the task. wait until now to append because easier to
+      # type/read 'step' than 'task$steps[[j]]' above
+      task$steps[[step$step_name]] <- step
+    }
+    tasks[[task$task_name]] <- task # wait until now to append to list because faster when coordinates is a long list
+  }
+  
+  return(tasks)
+}
+
+create_task_makefile <- function(task_plan, include=c(), packages=c(), sources=c(), makefile=NULL, template.file='../lib/task_makefile.mustache') {
+  
+  # prepare the variables to be rendered in the template
+  params <- list(
+    target_default = 'all',
+    include = include,
+    has_include = length(include) > 0,
+    packages = packages,
+    has_packages = length(packages) > 0,
+    sources = sources,
+    has_sources = length(sources) > 0,
+    tasks = task_plan
+  )
+  
+  # read the template
+  template <- readLines(template.file)
+  
+  # render the template
+  yml <- whisker::whisker.render(template, data=params)
+  yml <- gsub('[\n]{3,}', '\\\n\\\n', yml) # reduce 3+ line breaks to just 2
+  cat(yml)
+}
+create_task_makefile(tasks, packages='mda.streams')
+
+#' Evaluate a step element (target, depends, command) as a character
+#' string/vector, function of the task and step elements, or a default
+#'
+#' @keywords internal
+evaluate_step_element <- function(element, default, task, step) {
+  if(is.null(element)) {
+    return(evaluate_step_element(default, function(...) stop('default is undefined or NULL'), task, step))
+  } else if(is.character(element)) {
+    return(element)
+  } else if(is.function(element)) {
+    args <- c(task, step)
+    return(do.call(element, args))
+  }
+}

--- a/lib/create_task_makefile.R
+++ b/lib/create_task_makefile.R
@@ -1,51 +1,151 @@
-#' Create a templated remake YAML file that organizes tasks and their sub-tasks
-#' for a large number of targets
+# These functions are a first draft of the scipiper function. Let's see how it
+# goes.
+
+#' Create a .yml makefile for a multi-task job
 #'
-#' This function is a first draft of the scipiper function. Let's see how it
-#' goes.
+#' Create a .yml makefile (for use with remake or scipiper) for a set of tasks
+#' that together form a single job
 #'
-#' @param makefile
-#' @param include
-#' @param packages
-#' @param sources
+#' @param task_plan a task plan as produced by `create_task_plan()`
 #' @param job_target single character string naming the default target, which
 #'   will include all tasks within the job
-#' @param coordinates character vector of work coordinates, with length equal to
-#'   the number of tasks. These character strings will be used to prefix all
-#'   steps within a task. The prefix for each task should describe the aspect[s]
-#'   of a task that position it within the larger parameter space of work to be
-#'   done. Examples: site IDs, model names, character code describing specific
-#'   parameterization of model
-#' @param targets
-#' @param depends
-#' @param command
-#' @param ...
-#' @examples 
-#' step1 <- task_step(
+#' @param include character vector of any remake .yml files to include within
+#'   this one. If any files must be quoted in the remake file, quote them with
+#'   inner single quotes, e.g. `c("unquoted", "'quoted file name.tsv'")`
+#' @param packages character vector of any packages to load before running steps
+#' @param sources character vector of any files that should be sourced before
+#'   running steps. If any files must be quoted in the remake file, quote them
+#'   with inner single quotes, e.g. `c("unquoted", "'quoted file name.tsv'")`
+#' @param makefile character name of the remake file to create, or NULL to
+#'   simply return the output as a long character string (can be displayed in
+#'   console with `cat()`)
+#' @param template_file character name of the mustache template to render into
+#'   `makefile`. The default is recommended
+#' @return if `makefile==NULL`, the output as a long character string (can be
+#'   displayed with `cat()`). If `makefile` is a file name, the file name (can
+#'   be displayed with `readLines()`).
+#' @export
+#' @examples
+#' step1 <- create_task_step(
 #'   step_name = 'prep',
 #'   target = function(task_name, step_name, ...) {
 #'     sprintf('%s_%s', task_name, step_name)
 #'   },
 #'   depends = c('A','B'),
-#'   command = 'process(target_name, I("C"))'
+#'   command = "process(target_name, I('C'))"
 #' )
-#' step2 <- task_step(
+#' step2 <- create_task_step(
 #'   step_name = 'plot',
 #'   command = function(target_name, task_name, ...) {
-#'     sprintf('visualize("%s")', task_name)
+#'     sprintf('visualize(\'%s\')', task_name)
 #'   }
 #' )
-#' step3 <- task_step('report')
+#' step3 <- create_task_step('report')
 #' task_plan <- create_task_plan(c('AZ','CA','CO'), list(step1, step2, step3))
-create_task_plan <- function(coordinates, task_steps) {
+#' create_task_makefile(task_plan, packages='mda.streams')
+create_task_makefile <- function(task_plan, job_target = 'all', 
+                                 include=c(), packages=c(), sources=c(),
+                                 makefile=NULL, template_file='../lib/task_makefile.mustache') {
   
-  # munge the coordinates into a named list
-  coordinates <- if(is.data.frame(coordinates)) {
-    whisker::rowSplit(coordinates)
-  } else if(is.list(coordinates)) {
-    coordinates
-  } else if(is.character(coordinates)) {
-    setNames(as.list(rep(NA, length(coordinates))), coordinates)
+  # prepare the overall job task: list every step of every job as a dependency
+  job <- list(
+    target_name = job_target,
+    depends = unlist(lapply(task_plan, function(task) lapply(task$steps, function(step) step$target_name)), use.names=FALSE)
+  )
+  
+  # prepare the task list: remove names where they'd interfere with whisker.render
+  tasks <- unname(task_plan)
+  for(task in seq_along(tasks)) {
+    tasks[[task]]$steps <- unname(tasks[[task]]$steps)
+    for(step in seq_along(tasks[[task]]$steps)) {
+      tasks[[task]]$steps[[step]]$has_depends <- length(tasks[[task]]$steps[[step]]$depends) > 0
+    }
+  }
+  
+  # prepare the final list of variables to be rendered in the template
+  params <- list(
+    job = job,
+    target_default = overall_target,
+    include = include,
+    has_include = length(include) > 0,
+    packages = packages,
+    has_packages = length(packages) > 0,
+    sources = sources,
+    has_sources = length(sources) > 0,
+    tasks = tasks
+  )
+  
+  # read the template
+  template <- readLines(template_file)
+  
+  # render the template
+  yml <- whisker::whisker.render(template, data=params)
+  yml <- gsub('[\n]{3,}', '\\\n\\\n', yml) # reduce 3+ line breaks to just 2
+  
+  # write and/or return the results
+  if(!is.null(makefile)) {
+    cat(yml, file=makefile)
+    return(makefile)
+  } else {
+    return(yml)
+  }
+}
+
+#' Convert a task_plan into a status table
+#'
+#' Create a data.frame or .tsv file representing a task_plan and our status
+#' within that plan
+#' @param task_plan a task plan as produced by `create_task_plan()`
+#' @param table_file a file name to write a tab-separated table to (as .tsv), or
+#'   NULL to return as a data.frame
+#' @export
+create_task_table <- function(task_plan, table_file) {
+  stop("sorry, not implemented yet")
+}
+
+#' Define a set of tasks and steps within a single job
+#'
+#' Create a structured list that organizes tasks and their sub-tasks (steps) for
+#' a large number of near-identical tasks
+#'
+#' @param task_names character vector of IDs for sets of work coordinates, with
+#'   length equal to the number of tasks. You will usually use these character
+#'   strings within the names for each step in each task. These names should
+#'   therefore describe the aspect/aspects of a task that position it within the
+#'   larger parameter space of work to be done. Examples: site IDs, model names,
+#'   or character code identifying a unique row in a configuration file or
+#'   data.frame.
+#' @param task_steps list of definitions steps to perform within each task. Each
+#'   step definition should be created by `create_task_step()`
+#' @return a structured list that can be passed to `create_task_makefile` or
+#'   `create_task_table`
+#' @export
+#' @examples
+#' step1 <- create_task_step(
+#'   step_name = 'prep',
+#'   target = function(task_name, step_name, ...) {
+#'     sprintf('%s_%s', task_name, step_name)
+#'   },
+#'   depends = c('A','B'),
+#'   command = "process(target_name, I('C'))"
+#' )
+#' step2 <- create_task_step(
+#'   step_name = 'plot',
+#'   command = function(target_name, task_name, ...) {
+#'     sprintf('visualize(\'%s\')', task_name)
+#'   }
+#' )
+#' step3 <- create_task_step('report')
+#' task_plan <- create_task_plan(c('AZ','CA','CO'), list(step1, step2, step3))
+create_task_plan <- function(task_names, task_steps) {
+  
+  # munge the task_names into a named list
+  task_names <- if(is.data.frame(task_names)) {
+    whisker::rowSplit(task_names)
+  } else if(is.list(task_names)) {
+    task_names
+  } else if(is.character(task_names)) {
+    setNames(as.list(rep(NA, length(task_names))), task_names)
   }
   
   # check that task_steps is a list of task_steps
@@ -53,15 +153,15 @@ create_task_plan <- function(coordinates, task_steps) {
     stop('task_steps must be a list')
   } else {
     if(any(!sapply(task_steps, function(ts) is(ts, 'task_step')))) {
-      stop('task_steps must be a list of task_step objects (see ?task_step)')
+      stop('task_steps must be a list of task_step objects (see ?create_task_step)')
     }
   }
   
   # prepare a list of the tasks and steps
   tasks <- list()
-  for(i in seq_along(coordinates)) {
+  for(i in seq_along(task_names)) {
     task <- list(
-      task_name = names(coordinates)[i],
+      task_name = names(task_names)[i],
       steps = list()
     )
     for(j in seq_along(task_steps)) {
@@ -85,39 +185,22 @@ create_task_plan <- function(coordinates, task_steps) {
       task$steps[[step$step_name]] <- step
     }
     # append task to full tasks list. wait until now to append because faster
-    # when coordinates is a long list
+    # when task_names is a long list
     tasks[[task$task_name]] <- task
   }
   
   return(tasks)
 }
 
-#' Evaluate a step element (target, depends, command) as a character
-#' string/vector or as a function of the task and step elements (depending on the class of the element)
-#'
-#' @keywords internal
-evaluate_step_element <- function(task_step, element, task, step) {
-  # extract the desired task-step element (tse)
-  if(!element %in% names(task_step)) {
-    stop("task_step does not define the element '", element, "'")
-  }
-  tse <- task_step[[element]]
-  
-  # evaluate the tse according to its class
-  if(is.character(tse)) {
-    return(tse)
-  } else if(is.function(tse)) {
-    args <- c(task, step) # combine all available task-step info into a single list
-    return(do.call(tse, args)) # apply tse as a function of that info
-  }
-}
 #' Create an object that defines a step within a task
 #'
 #' The default values of each parameter are often acceptable, but all parameters
 #' may be overridden. When constructing the task makefile or table, the
 #' `target_name`, `depends`, and `command` elements are built in that order,
 #' with each element optionally depending on the result of the previous
-#' elements. They can also depend on the `step_name` (defined in this function call) and/or the `task_name` (defined in )
+#' elements. They can also depend on the `step_name` (defined in this function
+#' call) and/or the `task_name` (to be listed in a call to `create_task_plan()`,
+#' where the definitions declared here will ultimately be evaluated)
 #'
 #' @param step_name a single character string naming this step. The default
 #'   `target_name` combines this `step_name` with the `task_name`, and the
@@ -141,17 +224,21 @@ evaluate_step_element <- function(task_step, element, task, step) {
 #' @md
 #' @export
 #' @examples
-#' task_step(target_name=function(task_name, step_name, ...) {
-#'   sprintf('~/MyProjects/thisproject/%s_%s.png', task_name, step_name)
-#' }, command='plot_site(target_name)')
-task_step <- function(
+#' create_task_step(
+#'   'plot',
+#'   target_name=function(task_name, step_name, ...) {
+#'     sprintf('~/MyProjects/thisproject/%s_%s.png', task_name, step_name)
+#'   },
+#'   command='plot_site(target_name)'
+#' )
+create_task_step <- function(
   step_name,
   target_name = function(task_name, step_name, ...) {
     sprintf('%s_%s', task_name, step_name)
   },
   depends = character(0),
   command = function(task_name, step_name, ...) {
-    sprintf('%s("%s")', step_name, task_name)
+    sprintf("%s('%s')", step_name, task_name)
   }
 ) {
   
@@ -183,47 +270,45 @@ task_step <- function(
   return(step_def)
 }
 
-#' Create a .yml makefile (for use with remake) for a set of tasks that together
-#' form a single job
-#' 
-#' @examples
-#' create_task_makefile(task_plan, packages='mda.streams')
-create_task_makefile <- function(task_plan, job_target = 'all', 
-                                 include=c(), packages=c(), sources=c(),
-                                 makefile=NULL, template.file='../lib/task_makefile.mustache') {
-  
-  # prepare the variables to be rendered in the template
-  # prepare the overall job task
-  job <- list(
-    target_name = job_target,
-    depends = unlist(lapply(task_plan, function(task) lapply(task$steps, function(step) step$target_name)), use.names=FALSE)
-  )
-  params <- list(
-    job = job,
-    target_default = overall_target,
-    include = include,
-    has_include = length(include) > 0,
-    packages = packages,
-    has_packages = length(packages) > 0,
-    sources = sources,
-    has_sources = length(sources) > 0,
-    tasks = task_plan
-  )
-  
-  # remove names where they interfere with whisker.render
-  params$tasks <- unname(params$tasks)
-  for(task in seq_along(params$tasks)) {
-    params$tasks[[task]]$steps <- unname(params$tasks[[task]]$steps)
-    for(step in seq_along(params$tasks[[task]]$steps)) {
-      params$tasks[[task]]$steps[[step]]$has_depends <- length(params$tasks[[task]]$steps[[step]]$depends) > 0
-    }
+#' Evaluate a step element into simple strings
+#'
+#' Evaluate a step element (target, depends, command) as a character
+#' string/vector or as a function of the task and step elements (depending on
+#' the class of the element)
+#'
+#' @param task_step a task_step as created by `create_task_step()`
+#' @param element character naming a task_step element ('target_name',
+#'   'depends', or 'command') to evaluate
+#' @param task a task item: a list with fields for 'task_name' and possibly
+#'   other info
+#' @param step a step item: a list with fields for 'step_name' and possibly
+#'   other info
+#' @keywords internal
+evaluate_step_element <- function(task_step, element, task, step) {
+  # extract the desired task-step element (tse)
+  if(!element %in% names(task_step)) {
+    stop("task_step does not define the element '", element, "'")
   }
-
-  # read the template
-  template <- readLines(template.file)
+  tse <- task_step[[element]]
   
-  # render the template
-  yml <- whisker::whisker.render(template, data=params)
-  yml <- gsub('[\n]{3,}', '\\\n\\\n', yml) # reduce 3+ line breaks to just 2
-  cat(yml)
+  # evaluate the tse according to its class
+  if(is.character(tse)) {
+    out <- tse
+  } else if(is.function(tse)) {
+    args <- c(task, step) # combine all available task-step info into a single list
+    out <- do.call(tse, args) # apply tse as a function of that info
+  } else {
+    out <- tse # but we'll throw a warning below
+  }
+  
+  if(!is.character(out)) {
+    warning("output isn't character - that's probably bad")
+  }
+  if(any(grepl('"', out))) {
+    warning('in task=', task$task_name,
+            ', step=', step$step_name,
+            ', "',element , '":',
+            ' use \' instead of " to avoid html escaping')
+  }
+  return(out)
 }

--- a/lib/create_task_makefile.R
+++ b/lib/create_task_makefile.R
@@ -21,42 +21,23 @@
 #' @param command
 #' @param ...
 #' @examples 
-#' steps <- list(
-#'   step1 = list(
-#'     target = function(task_name, step_name, ...) {
-#'       sprintf('%s_%s', task_name, step_name)
-#'     },
-#'     depends = c('A','B'),
-#'     command = 'process(target_name)'
-#'   ),
-#'   step2 = list(
-#'     command = function(target, ...) {
-#'       sprintf('visualize(%s)', target)
-#'     }
-#'   )
+#' step1 <- task_step(
+#'   step_name = 'prep',
+#'   target = function(task_name, step_name, ...) {
+#'     sprintf('%s_%s', task_name, step_name)
+#'   },
+#'   depends = c('A','B'),
+#'   command = 'process(target_name, I("C"))'
 #' )
-#' task_plan <- create_task_plan(c('AZ','CA','CO'), .steps=steps)
-step_defaults <- list(
-  target = function(task_name, step_name, ...) {
-    sprintf('%s_%s', task_name, step_name)
-  },
-  depends = character(0),
-  command = function(step_name, ...) {
-    sprintf('%s(target_name)', step_name)
-  }
-)
-create_task_plan <- function(coordinates, ..., .steps, step_defaults=step_defaults) {
-  
-  # the steps definitions (steps_defs) can be passed in as [named] ... lists or
-  # in a big list named .steps
-  dotsteps <- list(...)
-  steps_defs <- if(missing(.steps)) {
-    dotsteps
-  } else if(length(dotsteps) > 0) {
-    stop("don't define both ... and .steps")
-  } else {
-    .steps
-  }
+#' step2 <- task_step(
+#'   step_name = 'plot',
+#'   command = function(target_name, task_name, ...) {
+#'     sprintf('visualize("%s")', task_name)
+#'   }
+#' )
+#' step3 <- task_step('report')
+#' task_plan <- create_task_plan(c('AZ','CA','CO'), list(step1, step2, step3))
+create_task_plan <- function(coordinates, task_steps) {
   
   # munge the coordinates into a named list
   coordinates <- if(is.data.frame(coordinates)) {
@@ -67,46 +48,157 @@ create_task_plan <- function(coordinates, ..., .steps, step_defaults=step_defaul
     setNames(as.list(rep(NA, length(coordinates))), coordinates)
   }
   
+  # check that task_steps is a list of task_steps
+  if(!is.list(task_steps)) {
+    stop('task_steps must be a list')
+  } else {
+    if(any(!sapply(task_steps, function(ts) is(ts, 'task_step')))) {
+      stop('task_steps must be a list of task_step objects (see ?task_step)')
+    }
+  }
+  
   # prepare a list of the tasks and steps
   tasks <- list()
-  seq_coords <- seq_along(coordinates)
-  seq_steps <- seq_along(steps_defs)
-  for(i in seq_coords) {
+  for(i in seq_along(coordinates)) {
     task <- list(
       task_name = names(coordinates)[i],
       steps = list()
     )
-    for(j in seq_steps) {
+    for(j in seq_along(task_steps)) {
       # isolate just the definitions for this step
-      step_def <- steps_defs[[j]]
+      step_def <- task_steps[[j]]
       
       # every step is a list with step_name as the first element
       step <- list()
-      step$step_name = names(steps_defs)[[j]]
+      step$step_name = step_def$step_name
       
       # use the user's step definitions to define the recipe
-      step$target <- evaluate_step_element(step_def$target, step_defaults$target, task, step)
-      step$depends <- evaluate_step_element(step_def$depends, step_defaults$depends, task, step)
-      step$command <- evaluate_step_element(step_def$command, step_defaults$command, task, step)
+      step$target_name <- evaluate_step_element(step_def, 'target_name', task, step)
+      step$depends <- evaluate_step_element(step_def, 'depends', task, step)
+      step$command <- evaluate_step_element(step_def, 'command', task, step)
       
-      # add a T/F to help whisker avoid empty depends blocks
+      # add a T/F to help whisker avoid empty depends blocks. move this to the makefile function soon
       step$has_depends <- length(step$depends) > 0
       
       # add this step to the task. wait until now to append because easier to
       # type/read 'step' than 'task$steps[[j]]' above
       task$steps[[step$step_name]] <- step
     }
-    tasks[[task$task_name]] <- task # wait until now to append to list because faster when coordinates is a long list
+    # append task to full tasks list. wait until now to append because faster
+    # when coordinates is a long list
+    tasks[[task$task_name]] <- task
   }
   
   return(tasks)
 }
 
-create_task_makefile <- function(task_plan, include=c(), packages=c(), sources=c(), makefile=NULL, template.file='../lib/task_makefile.mustache') {
+#' Evaluate a step element (target, depends, command) as a character
+#' string/vector or as a function of the task and step elements (depending on the class of the element)
+#'
+#' @keywords internal
+evaluate_step_element <- function(task_step, element, task, step) {
+  # extract the desired task-step element (tse)
+  if(!element %in% names(task_step)) {
+    stop("task_step does not define the element '", element, "'")
+  }
+  tse <- task_step[[element]]
+  
+  # evaluate the tse according to its class
+  if(is.character(tse)) {
+    return(tse)
+  } else if(is.function(tse)) {
+    args <- c(task, step) # combine all available task-step info into a single list
+    return(do.call(tse, args)) # apply tse as a function of that info
+  }
+}
+#' Create an object that defines a step within a task
+#'
+#' The default values of each parameter are often acceptable, but all parameters
+#' may be overridden. When constructing the task makefile or table, the
+#' `target_name`, `depends`, and `command` elements are built in that order,
+#' with each element optionally depending on the result of the previous
+#' elements. They can also depend on the `step_name` (defined in this function call) and/or the `task_name` (defined in )
+#'
+#' @param step_name a single character string naming this step. The default
+#'   `target_name` combines this `step_name` with the `task_name`, and the
+#'   default `command` assumes this `step_name` is the function name, but both
+#'   defaults may be overridden (see next arguments)
+#' @param target_name a character string or vector, or a function that produces
+#'   a character string or vector, giving a unique name for the remake target
+#'   for a specific application of this step to a specific task. If a function,
+#'   should accept `...` and other args optionally including `task_name` and
+#'   `step_name`
+#' @param depends a character string or vector, or a function that produces a
+#'   character string or vector, defining any dependencies that need to be
+#'   declared in addition to those implied by `command`. If a function, should
+#'   accept `...` and other args optionally including `task_name`, `step_name`,
+#'   and `target_name` args optionally including `task_name` and `step_name`
+#' @param command a character string or vector, or a function that produces a
+#'   character string or vector, defining the command to be run for each
+#'   application of this step to a specific task. If a function, should accept
+#'   `...` and other args optionally including `task_name`, `step_name`,
+#'   `target_name`, and `depends`
+#' @md
+#' @export
+#' @examples
+#' task_step(target_name=function(task_name, step_name, ...) {
+#'   sprintf('~/MyProjects/thisproject/%s_%s.png', task_name, step_name)
+#' }, command='plot_site(target_name)')
+task_step <- function(
+  step_name,
+  target_name = function(task_name, step_name, ...) {
+    sprintf('%s_%s', task_name, step_name)
+  },
+  depends = character(0),
+  command = function(task_name, step_name, ...) {
+    sprintf('%s("%s")', step_name, task_name)
+  }
+) {
+  
+  # create the step definition
+  step_def <- list(step_name=step_name, target_name=target_name, depends=depends, command=command)
+  class(step_def) <- 'task_step'
+  
+  # check the inputs for proper formatting
+  for(elem_name in names(step_def)) {
+    element <- step_def[[elem_name]]
+    if(is.character(element)) {
+      # this is fine
+    } else if(is.function(element)) {
+      # check that the arguments are as expected
+      given_args <- names(formals(element))
+      expected_args <- c('...','task_name','step_name','target_name','depends')
+      unknown_args <- setdiff(given_args, expected_args)
+      if(length(unknown_args) > 0) {
+        stop(paste0("unknown argument name[s] ",paste("'",unknown_args,"'", collapse=", ")," in '", elem_name, "' element"))
+      }
+      if(!('...' %in% given_args)) {
+        stop(paste0("'...' must be included in arguments to ", elem_name))
+      }
+    } else {
+      stop('each element must be either a character string/vector or a function')
+    }
+  }
+  
+  return(step_def)
+}
+
+#' Create a .yml makefile (for use with remake) for a set of tasks that together
+#' form a single job
+#' 
+#' @examples
+#' create_task_makefile(task_plan, packages='mda.streams')
+create_task_makefile <- function(task_plan, job_target = 'all', 
+                                 include=c(), packages=c(), sources=c(),
+                                 makefile=NULL, template.file='../lib/task_makefile.mustache') {
   
   # prepare the variables to be rendered in the template
   params <- list(
-    target_default = 'all',
+    job = list(
+      target_name = job_target,
+      depends = lapply(unname(task_plan), function(task) { task$steps[[length(task$steps)]]$target_name })
+    ),
+    target_default = overall_target,
     include = include,
     has_include = length(include) > 0,
     packages = packages,
@@ -116,6 +208,15 @@ create_task_makefile <- function(task_plan, include=c(), packages=c(), sources=c
     tasks = task_plan
   )
   
+  # remove names where they interfere with whisker.render
+  params$tasks <- unname(params$tasks)
+  for(task in seq_along(params$tasks)) {
+    params$tasks[[task]]$steps <- unname(params$tasks[[task]]$steps)
+    for(step in seq_along(params$tasks[[task]]$steps)) {
+      params$tasks[[task]]$steps[[step]]$has_depends <- length(params$tasks[[task]]$steps[[step]]$depends) > 0
+    }
+  }
+
   # read the template
   template <- readLines(template.file)
   
@@ -123,20 +224,4 @@ create_task_makefile <- function(task_plan, include=c(), packages=c(), sources=c
   yml <- whisker::whisker.render(template, data=params)
   yml <- gsub('[\n]{3,}', '\\\n\\\n', yml) # reduce 3+ line breaks to just 2
   cat(yml)
-}
-create_task_makefile(tasks, packages='mda.streams')
-
-#' Evaluate a step element (target, depends, command) as a character
-#' string/vector, function of the task and step elements, or a default
-#'
-#' @keywords internal
-evaluate_step_element <- function(element, default, task, step) {
-  if(is.null(element)) {
-    return(evaluate_step_element(default, function(...) stop('default is undefined or NULL'), task, step))
-  } else if(is.character(element)) {
-    return(element)
-  } else if(is.function(element)) {
-    args <- c(task, step)
-    return(do.call(element, args))
-  }
 }

--- a/lib/create_task_makefile.R
+++ b/lib/create_task_makefile.R
@@ -44,7 +44,7 @@
 #' task_plan <- create_task_plan(c('AZ','CA','CO'), list(step1, step2, step3))
 #' create_task_makefile(task_plan, packages='mda.streams')
 create_task_makefile <- function(task_plan, job_target = 'all', 
-                                 include=c(), packages=c(), sources=c(),
+                                 include=c(), packages=c(), sources=c(), file_extensions=c(),
                                  makefile=NULL, template_file='../lib/task_makefile.mustache') {
   
   # prepare the overall job task: list every step of every job as a dependency
@@ -65,13 +65,15 @@ create_task_makefile <- function(task_plan, job_target = 'all',
   # prepare the final list of variables to be rendered in the template
   params <- list(
     job = job,
-    target_default = overall_target,
+    target_default = job_target,
     include = include,
     has_include = length(include) > 0,
     packages = packages,
     has_packages = length(packages) > 0,
     sources = sources,
     has_sources = length(sources) > 0,
+    file_extensions = file_extensions,
+    has_file_extensions = length(file_extensions) > 0,
     tasks = tasks
   )
   

--- a/lib/create_task_makefile.R
+++ b/lib/create_task_makefile.R
@@ -193,11 +193,13 @@ create_task_makefile <- function(task_plan, job_target = 'all',
                                  makefile=NULL, template.file='../lib/task_makefile.mustache') {
   
   # prepare the variables to be rendered in the template
+  # prepare the overall job task
+  job <- list(
+    target_name = job_target,
+    depends = unlist(lapply(task_plan, function(task) lapply(task$steps, function(step) step$target_name)), use.names=FALSE)
+  )
   params <- list(
-    job = list(
-      target_name = job_target,
-      depends = lapply(unname(task_plan), function(task) { task$steps[[length(task$steps)]]$target_name })
-    ),
+    job = job,
     target_default = overall_target,
     include = include,
     has_include = length(include) > 0,

--- a/lib/task_makefile.mustache
+++ b/lib/task_makefile.mustache
@@ -1,0 +1,43 @@
+target_default: {{target_default}}
+
+{{#has_include}}
+include:
+{{#include}}
+  - {{.}}
+{{/include}}
+{{/has_include}}
+
+{{#has_packages}}
+packages:
+{{#packages}}
+  - {{.}}
+{{/packages}}
+{{/has_packages}}
+
+{{#has_sources}}
+sources:
+{{#sources}}
+  - {{.}}
+{{/sources}}
+{{/has_sources}}
+
+targets:
+  {{target_default}}:
+    depends: 
+      - user.spatial.catchments
+
+{{#tasks}}
+  # --- {{task_name}} ---
+  
+{{#steps}}
+  {{target}}:
+    command: {{command}}
+{{#has_depends}}
+    depends:
+{{#depends}}
+      - {{.}}
+{{/depends}}
+{{/has_depends}}
+
+{{/steps}}
+{{/tasks}}

--- a/lib/task_makefile.mustache
+++ b/lib/task_makefile.mustache
@@ -21,15 +21,14 @@ sources:
 {{/sources}}
 {{/has_sources}}
 
-targets:
-{{#job}}
-  {{target_name}}:
-    depends: 
-{{#depends}}
-      - {{.}}
-{{/depends}}
-{{/job}}
+{{#has_file_extensions}}
+file_extensions:
+{{#file_extensions}}
+  - "{{.}}"
+{{/file_extensions}}
+{{/has_file_extensions}}
 
+targets:
 {{#tasks}}
   # --- {{task_name}} --- #
   
@@ -45,3 +44,11 @@ targets:
 
 {{/steps}}
 {{/tasks}}
+
+{{#job}}
+  {{target_name}}:
+    depends: 
+{{#depends}}
+      - {{.}}
+{{/depends}}
+{{/job}}

--- a/lib/task_makefile.mustache
+++ b/lib/task_makefile.mustache
@@ -1,4 +1,4 @@
-target_default: {{target_default}}
+target_default: {{#job}}{{target_name}}{{/job}}
 
 {{#has_include}}
 include:
@@ -22,15 +22,19 @@ sources:
 {{/has_sources}}
 
 targets:
-  {{target_default}}:
+{{#job}}
+  {{target_name}}:
     depends: 
-      - user.spatial.catchments
+{{#depends}}
+      - {{.}}
+{{/depends}}
+{{/job}}
 
 {{#tasks}}
-  # --- {{task_name}} ---
+  # --- {{task_name}} --- #
   
 {{#steps}}
-  {{target}}:
+  {{target_name}}:
     command: {{command}}
 {{#has_depends}}
     depends:

--- a/remake/4_release_models.yml
+++ b/remake/4_release_models.yml
@@ -1,0 +1,60 @@
+target_default: 4_release_models
+
+include:
+  - 2_metab_outputs.yml # 1_site_data.yml and 2_metab_models.yml get included via this file
+  - 4_release_parent.yml
+  
+packages:
+  - yaml
+  - whisker
+  - dplyr
+  - meddle
+  - mda.streams
+  
+sources:
+  - ../4_data_release/code/post_data_release.R
+  - ../4_data_release/code/model_release_tasks.R
+  - ../lib/load_profile.R
+  - ../lib/create_task_makefile.R
+  
+targets:
+  4_release_models:
+    depends: 
+      - model_release_plan
+  #    - release_model_inputs
+  #    - release_model_preds
+  #    - release_model_fits
+  
+  # -- munge & write data for release --
+  
+  model_release_plan:
+    depends: '../lib/task_makefile.mustache'
+    command: create_model_release_task_plan(metab.config)
+  
+  4e_model_release.yml:
+    command: create_model_release_makefile(makefile=target_name, task_plan=model_release_plan)
+
+  # -- create tables with partial info to complete manually --
+  
+  #../4_data_release/in/site_data_attr.csv:
+  #  command: attribute_skeleton(meta_all_df, target_name)
+    
+  # -- read manual entry and extracted metadata -- 
+  
+  #site_data_attr:
+  #  command: as.attr_list('../4_data_release/in/site_data_attr.csv')
+  
+  # -- create final metadata files --
+  
+  #../4_data_release/out/site_data.xml:
+  #  command: render("../4_data_release/in/metadata_site_data.yaml", target_name, points_meta, site_data_attr, parent_metadata)
+
+  # -- SB posting: create the items to host data and metadata --
+
+  #pc1_site_metadata:
+  #  command: create_release_child(stream_metab_powell_release, target_name)
+  
+  # -- final targets: post data and metadata to SB --
+  
+  #release_site_data:
+  #  command: create_release_item(pc1_site_metadata, target_name, '../4_data_release/cache/site_data.tsv', '../4_data_release/out/site_data.xml')


### PR DESCRIPTION
Draft of functions to create a task_plan (a list describing many tasks, 1-several steps per task) and a corresponding remake file.

Examples of use:
```
step1 <- create_task_step(
  step_name = 'prep',
  target = function(task_name, step_name, ...) {
    sprintf('%s_%s', task_name, step_name)
  },
  depends = c('A','B'),
  command = "process(target_name, I('C'))"
)
step2 <- create_task_step(
  step_name = 'plot',
  command = function(target_name, task_name, ...) {
    sprintf('visualize(\'%s\')', task_name)
  }
)
step3 <- create_task_step('report')
task_plan <- create_task_plan(c('AZ','CA','CO'), list(step1, step2, step3))
create_task_makefile(task_plan, packages='mda.streams')
```

For another example, see 4_data_release/code/model_release_tasks.R and remake/4_release_models.yml, which are my first attempt at applying the new functions & mustache template to downloading and extracting info from models. These files aren't completely functional yet but are in an OK place to merge, and they should do more to help than hinder you (@jread-usgs) from working on a similar workflow for timeseries data.
