### PR TITLE
multi-task job now writes status file by default

### DIFF
--- a/4_data_release/code/model_release_tasks.R
+++ b/4_data_release/code/model_release_tasks.R
@@ -50,11 +50,14 @@ create_model_release_task_plan <- function(metab.config) {
 }
 
 create_model_release_makefile <- function(makefile, task_plan) {
+  st_dir <- '../4_data_release/log'
+  if(!dir.exists(st_dir)) dir.create(st_dir)
   create_task_makefile(
     makefile=makefile, task_plan=task_plan,
-    job_target = 'model_release', include = '4_release_models.yml',
+    job_target = file.path(st_dir, 'model_release.st'),
+    include = '4_release_models.yml',
     packages=c('mda.streams', 'streamMetabolizer', 'dplyr'),
-    file_extensions=c('RData'))
+    file_extensions=c('st','RData'))
 }
 
 download_model <- function(model_name, folder, version) {

--- a/lib/create_task_makefile.R
+++ b/lib/create_task_makefile.R
@@ -8,7 +8,10 @@
 #'
 #' @param task_plan a task plan as produced by `create_task_plan()`
 #' @param job_target single character string naming the default target, which
-#'   will include all tasks within the job
+#'   will include all tasks within the job. It's usually best for job_target to
+#'   be a status indicator file name.
+#' @param job_command character string defining a remake command to create the
+#'   `job_target`
 #' @param include character vector of any remake .yml files to include within
 #'   this one. If any files must be quoted in the remake file, quote them with
 #'   inner single quotes, e.g. `c("unquoted", "'quoted file name.tsv'")`
@@ -47,14 +50,22 @@
 #' )
 #' step3 <- create_task_step('report')
 #' task_plan <- create_task_plan(c('AZ','CA','CO'), list(step1, step2, step3))
-#' cat(create_task_makefile(task_plan, packages='mda.streams'))
-create_task_makefile <- function(task_plan, job_target = 'all', 
-                                 include=c(), packages=c(), sources=c(), file_extensions=c(),
-                                 makefile=NULL, template_file='../lib/task_makefile.mustache') {
+#' cat(create_task_makefile(task_plan, job_target='states.st', file_extensions=c('st'), packages='mda.streams'))
+create_task_makefile <- function(
+  task_plan, job_target, 
+  job_command="writeJobTimestamp(target_name)",
+  include=c(), packages=c(), sources=c(), file_extensions=c(),
+  makefile=NULL, template_file='../lib/task_makefile.mustache') {
   
-  # prepare the overall job task: list every step of every job as a dependency
+  # prepare the overall job task: list every step of every job as a dependency.
+  # start by encouraging users to make job_target be a file
+  job_target_is_file <- (file_ext(job_target) %in% c(remake::file_extensions(), file_extensions))
+  if(!job_target_is_file) {
+    warning('a filename target is recommended for job_target (and should be written by job_command)')
+  }
   job <- list(
     target_name = job_target,
+    command = job_command,
     depends = unlist(lapply(task_plan, function(task) lapply(task$steps, function(step) step$target_name)), use.names=FALSE)
   )
   
@@ -96,6 +107,10 @@ create_task_makefile <- function(task_plan, job_target = 'all',
   } else {
     return(yml)
   }
+}
+
+writeJobTimestamp <- function(job_target) {
+  writeLines(text=format(Sys.time(), '%Y-%m-%d %H:%M:%S UTC', tz='UTC'), con=job_target)
 }
 
 #' Convert a task_plan into a status table

--- a/lib/create_task_makefile.R
+++ b/lib/create_task_makefile.R
@@ -54,12 +54,12 @@
 create_task_makefile <- function(
   task_plan, job_target, 
   job_command="writeJobTimestamp(target_name)",
-  include=c(), packages=c(), sources=c(), file_extensions=c(),
+  include=c(), packages=c(), sources=c(), file_extensions=c('st'),
   makefile=NULL, template_file='../lib/task_makefile.mustache') {
   
   # prepare the overall job task: list every step of every job as a dependency.
   # start by encouraging users to make job_target be a file
-  job_target_is_file <- (file_ext(job_target) %in% c(remake::file_extensions(), file_extensions))
+  job_target_is_file <- (tools::file_ext(job_target) %in% c(remake::file_extensions(), file_extensions))
   if(!job_target_is_file) {
     warning('a filename target is recommended for job_target (and should be written by job_command)')
   }

--- a/lib/create_task_makefile.R
+++ b/lib/create_task_makefile.R
@@ -26,6 +26,10 @@
 #'   be displayed with `readLines()`).
 #' @export
 #' @examples
+#' task_config <- data.frame(
+#'   id=c('AZ','CO','CA'),
+#'   capital=c('Phoeniz','Denver','Sacramento')
+#' )
 #' step1 <- create_task_step(
 #'   step_name = 'prep',
 #'   target = function(task_name, step_name, ...) {
@@ -37,12 +41,13 @@
 #' step2 <- create_task_step(
 #'   step_name = 'plot',
 #'   command = function(target_name, task_name, ...) {
-#'     sprintf('visualize(\'%s\')', task_name)
+#'     capital <- task_config[task_config$id == task_name, 'capital']
+#'     sprintf('visualize(\'%s\', \'%s\')', task_name, capital)
 #'   }
 #' )
 #' step3 <- create_task_step('report')
 #' task_plan <- create_task_plan(c('AZ','CA','CO'), list(step1, step2, step3))
-#' create_task_makefile(task_plan, packages='mda.streams')
+#' cat(create_task_makefile(task_plan, packages='mda.streams'))
 create_task_makefile <- function(task_plan, job_target = 'all', 
                                  include=c(), packages=c(), sources=c(), file_extensions=c(),
                                  makefile=NULL, template_file='../lib/task_makefile.mustache') {
@@ -123,6 +128,10 @@ create_task_table <- function(task_plan, table_file) {
 #'   `create_task_table`
 #' @export
 #' @examples
+#' task_config <- data.frame(
+#'   id=c('AZ','CO','CA'),
+#'   capital=c('Phoeniz','Denver','Sacramento')
+#' )
 #' step1 <- create_task_step(
 #'   step_name = 'prep',
 #'   target = function(task_name, step_name, ...) {
@@ -134,7 +143,8 @@ create_task_table <- function(task_plan, table_file) {
 #' step2 <- create_task_step(
 #'   step_name = 'plot',
 #'   command = function(target_name, task_name, ...) {
-#'     sprintf('visualize(\'%s\')', task_name)
+#'     capital <- task_config[task_config$id == task_name, 'capital']
+#'     sprintf('visualize(\'%s\', \'%s\')', task_name, capital)
 #'   }
 #' )
 #' step3 <- create_task_step('report')

--- a/lib/task_makefile.mustache
+++ b/lib/task_makefile.mustache
@@ -47,6 +47,7 @@ targets:
 
 {{#job}}
   {{target_name}}:
+    command: {{command}}
     depends: 
 {{#depends}}
       - {{.}}


### PR DESCRIPTION
with example application to model_release_tasks:

In model_release_tasks.R, line 52:
```
create_model_release_makefile <- function(makefile, task_plan) {
  st_dir <- '../4_data_release/log'
  if(!dir.exists(st_dir)) dir.create(st_dir)
  create_task_makefile(
    makefile=makefile, task_plan=task_plan,
    job_target = file.path(st_dir, 'model_release.st'),
    include = '4_release_models.yml',
    packages=c('mda.streams', 'streamMetabolizer', 'dplyr'),
    file_extensions=c('st','RData'))
}
```
(`job_target` is now a file; using default `job_command` to write a timestamp to that file when all tasks and steps are complete)

In 4e_model_release.yml, line 3480: 
```
  ../4_data_release/log/model_release.st:
    command: writeJobTimestamp(target_name)
    depends: 
      - '../4_data_release/cache/models/mm_nwis_01548303-1-170406 1.0.2 bayes_15min.RData'
      - '../4_data_release/cache/models/inputs.nwis_01548303-1-170406 1.0.2 bayes_15min.rds'
      - '../4_data_release/cache/models/mm_nwis_02168504-2-170406 1.0.2 bayes_60min.RData'
      - '../4_data_release/cache/models/inputs.nwis_02168504-2-170406 1.0.2 bayes_60min.rds'
...
```
(job target is the main, default target, and gets a timestamp written to it when everything is done)