### PR TITLE
Spatial meta

### DIFF
--- a/4_data_release/code/create_fgdc_template.R
+++ b/4_data_release/code/create_fgdc_template.R
@@ -87,10 +87,11 @@ create_fgdc_template <- function(file.out, multiple_entities=FALSE){
   ci <- pt %>% 
     xml_add_child('cntinfo') %>% 
     xml_add_child('cntperp') 
+  
   ci %>% 
     xml_add_child('cntper','{{contact-person}}') %>% 
-    xml_add_sibling('cntorg','U.S. Geological Survey') %>%
-    xml_add_child('cntpos','{{contact-position}}')
+    xml_add_sibling('cntorg','U.S. Geological Survey')
+  
   
   adr <- ci %>% xml_add_sibling('cntaddr') 
   adr %>%
@@ -100,7 +101,8 @@ create_fgdc_template <- function(file.out, multiple_entities=FALSE){
     xml_add_sibling('state','{{contact-state}}') %>% 
     xml_add_sibling('postal','{{contact-zip}}') %>% 
     xml_add_sibling('country','U.S.A.')
-  
+  ci %>% 
+    xml_add_sibling('cntpos','{{contact-position}}')
   adr %>% xml_add_sibling('cntvoice','{{contact-phone}}') %>% 
     xml_add_sibling('cntemail','{{contact-email}}')
   

--- a/4_data_release/in/fgdc_template.xml
+++ b/4_data_release/in/fgdc_template.xml
@@ -84,8 +84,9 @@
       <cntinfo>
         <cntperp>
           <cntper>{{contact-person}}</cntper>
-          <cntorg>U.S. Geological Survey<cntpos>{{contact-position}}</cntpos></cntorg>
+          <cntorg>U.S. Geological Survey</cntorg>
         </cntperp>
+        <cntpos>{{contact-position}}</cntpos>
         <cntaddr>
           <addrtype>Mailing and Physical</addrtype>
           <address>{{contact-address}}</address>

--- a/4_data_release/in/fgdc_template_ents.xml
+++ b/4_data_release/in/fgdc_template_ents.xml
@@ -84,8 +84,9 @@
       <cntinfo>
         <cntperp>
           <cntper>{{contact-person}}</cntper>
-          <cntorg>U.S. Geological Survey<cntpos>{{contact-position}}</cntpos></cntorg>
+          <cntorg>U.S. Geological Survey</cntorg>
         </cntperp>
+        <cntpos>{{contact-position}}</cntpos>
         <cntaddr>
           <addrtype>Mailing and Physical</addrtype>
           <address>{{contact-address}}</address>

--- a/4_data_release/in/metadata_parent.yaml
+++ b/4_data_release/in/metadata_parent.yaml
@@ -32,7 +32,7 @@ purpose: >-
   metabolism (gross primary productivity and ecosystem respiration)
   for 356 streams and rivers across the United States.
 start-date: 20071001
-end-date: 12
+end-date: !expr format(as.Date(yaml::yaml.load_file('../1_timeseries/in/ts_config.yml')$times[[2]], '%Y-%m-%d'), '%Y%m%d')
 
 # ----associated publication----
 cite-authors: ["Alison P Appling","Jordan S Read","Luke A Winslow", "Maite Arroita", "Emily Bernhardt", "Natalie Griffiths", "Robert Hall", "Judson Harvey", "Jim Heffernan", "Emily Stanley", "Edward Stets", "Charles Yackulic"]

--- a/4_data_release/in/metadata_parent.yaml
+++ b/4_data_release/in/metadata_parent.yaml
@@ -47,14 +47,14 @@ journal: Nature Scientific Data
 contact-person: Alison P. Appling
 contact-phone: 520-670-6671 x271
 contact-email: aappling@usgs.gov
-contact-position: Ecologist, Data Science Branch, Integrated Information Dissemination Division, U.S. Geological Survey
+contact-position: Ecologist
 contact-address: 520 N Park Ave, Ste 221
 contact-city: Tucson
 contact-state: AZ
 contact-zip: 85719
 
 metadata-person: Jordan S. Read
-metadata-position: Chief, Data Science Branch, Integrated Information Dissemination Division, U.S. Geological Survey
+metadata-position: Research Civil Engineer
 metadata-phone: 608-821-3922
 metadata-fax: 608-821-3817
 metadata-email: jread@usgs.gov
@@ -63,7 +63,7 @@ metadata-city: Middleton
 metadata-state: WI
 metadata-zip: 53562
 
-# ----distribtution----
+# ----distribution----
 
 # statement for "Preliminary (provisional) data, information, or software" (https://www2.usgs.gov/fsp/fsp_disclaimers.asp):
 liability-statement: >-

--- a/4_data_release/in/metadata_parent.yaml
+++ b/4_data_release/in/metadata_parent.yaml
@@ -32,7 +32,7 @@ purpose: >-
   metabolism (gross primary productivity and ecosystem respiration)
   for 356 streams and rivers across the United States.
 start-date: 20071001
-end-date: !expr format(as.Date(yaml::yaml.load_file('../1_timeseries/in/ts_config.yml')$times[[2]], '%Y-%m-%d'), '%Y%m%d')
+end-date: 12
 
 # ----associated publication----
 cite-authors: ["Alison P Appling","Jordan S Read","Luke A Winslow", "Maite Arroita", "Emily Bernhardt", "Natalie Griffiths", "Robert Hall", "Judson Harvey", "Jim Heffernan", "Emily Stanley", "Edward Stets", "Charles Yackulic"]

--- a/4_data_release/out/site_catchment_shapefile.xml
+++ b/4_data_release/out/site_catchment_shapefile.xml
@@ -29,7 +29,7 @@
       <timeinfo>
         <rngdates>
           <begdate>20071001</begdate>
-          <enddate>12</enddate>
+          <enddate>20170101</enddate>
         </rngdates>
       </timeinfo>
       <current>model estimates</current>

--- a/4_data_release/out/site_catchment_shapefile.xml
+++ b/4_data_release/out/site_catchment_shapefile.xml
@@ -29,7 +29,7 @@
       <timeinfo>
         <rngdates>
           <begdate>20071001</begdate>
-          <enddate>dog</enddate>
+          <enddate>20170101</enddate>
         </rngdates>
       </timeinfo>
       <current>model estimates</current>

--- a/4_data_release/out/site_catchment_shapefile.xml
+++ b/4_data_release/out/site_catchment_shapefile.xml
@@ -29,7 +29,7 @@
       <timeinfo>
         <rngdates>
           <begdate>20071001</begdate>
-          <enddate>20170101</enddate>
+          <enddate>dog</enddate>
         </rngdates>
       </timeinfo>
       <current>model estimates</current>

--- a/4_data_release/out/site_catchment_shapefile.xml
+++ b/4_data_release/out/site_catchment_shapefile.xml
@@ -29,7 +29,7 @@
       <timeinfo>
         <rngdates>
           <begdate>20071001</begdate>
-          <enddate>20170101</enddate>
+          <enddate>12</enddate>
         </rngdates>
       </timeinfo>
       <current>model estimates</current>

--- a/4_data_release/out/site_catchment_shapefile.xml
+++ b/4_data_release/out/site_catchment_shapefile.xml
@@ -171,8 +171,9 @@
       <cntinfo>
         <cntperp>
           <cntper>Alison P. Appling</cntper>
-          <cntorg>U.S. Geological Survey<cntpos>Ecologist, Data Science Branch, Integrated Information Dissemination Division, U.S. Geological Survey</cntpos></cntorg>
+          <cntorg>U.S. Geological Survey</cntorg>
         </cntperp>
+        <cntpos>Ecologist</cntpos>
         <cntaddr>
           <addrtype>Mailing and Physical</addrtype>
           <address>520 N Park Ave, Ste 221</address>
@@ -188,7 +189,7 @@
     <datacred>This work was funded by the USGS Powell Center (Working Group title: "Continental-scale overview of stream primary productivity, its links to water quality, and consequences for aquatic carbon biogeochemistry"). Additional financial support came from the USGS NAWQA program and Office of Water Information. NSF grants DEB-1146283 and EF1442501 partially supported ROH. The USGS Wisconsin Modeling Center provided access to the HTCondor cluster for generating metabolism estimates.</datacred>
     <native>This dataset was generated using open source tools available in the R programming language (R version 3.4.1 (2017-06-30)).
   The computing platform for generating data and metadata was x86_64-apple-darwin15.6.0. 
-  R packages loaded into this environment: maptools, version: 0.9-2; mda.streams, version: 0.9.24; meddle, version: 0.0.4; maps, version: 3.2.0; dataRetrieval, version: 2.7.4; rgeos, version: 0.3-26; dplyr, version: 0.7.4; sbtools, version: 1.1.6; httr, version: 1.3.1; rgdal, version: 1.2-16; whisker, version: 0.3-2; yaml, version: 2.1.16; xml2, version: 1.1.1; magrittr, version: 1.5; sp, version: 1.2-6.</native>
+  R packages loaded into this environment: maptools, version: 0.9-2; mda.streams, version: 0.9.24; meddle, version: 0.0.4; maps, version: 3.2.0; dataRetrieval, version: 2.7.4; rgeos, version: 0.3-26; dplyr, version: 0.7.4; sbtools, version: 1.1.6; httr, version: 1.3.1; rgdal, version: 1.2-16; sp, version: 1.2-6; whisker, version: 0.3-2; yaml, version: 2.1.16; xml2, version: 1.2.0; magrittr, version: 1.5.</native>
   </idinfo>
   <dataqual>
     <attracc>
@@ -370,7 +371,7 @@
       </srcinfo>
       <procstep>
         <procdesc>Existing polygons were combined from various sources (see data_source attribute and Source Information). Spatial tools in the R programming language were used to perform the operations of merging  and modifying attributes. </procdesc>
-        <procdate>20180116</procdate>
+        <procdate>20180305</procdate>
       </procstep>
     </lineage>
   </dataqual>
@@ -471,14 +472,14 @@
     </stdorder>
   </distinfo>
   <metainfo>
-    <metd>20180116</metd>
+    <metd>20180305</metd>
     <metc>
       <cntinfo>
         <cntperp>
           <cntper>Jordan S. Read</cntper>
           <cntorg>U.S. Geological Survey</cntorg>
         </cntperp>
-        <cntpos>Chief, Data Science Branch, Integrated Information Dissemination Division, U.S. Geological Survey</cntpos>
+        <cntpos>Research Civil Engineer</cntpos>
         <cntaddr>
           <addrtype>Mailing and Physical</addrtype>
           <address>8551 Research Way #120</address>

--- a/4_data_release/out/site_catchment_shapefile.xml
+++ b/4_data_release/out/site_catchment_shapefile.xml
@@ -189,7 +189,7 @@
     <datacred>This work was funded by the USGS Powell Center (Working Group title: "Continental-scale overview of stream primary productivity, its links to water quality, and consequences for aquatic carbon biogeochemistry"). Additional financial support came from the USGS NAWQA program and Office of Water Information. NSF grants DEB-1146283 and EF1442501 partially supported ROH. The USGS Wisconsin Modeling Center provided access to the HTCondor cluster for generating metabolism estimates.</datacred>
     <native>This dataset was generated using open source tools available in the R programming language (R version 3.4.1 (2017-06-30)).
   The computing platform for generating data and metadata was x86_64-apple-darwin15.6.0. 
-  R packages loaded into this environment: maptools, version: 0.9-2; mda.streams, version: 0.9.24; meddle, version: 0.0.4; maps, version: 3.2.0; dataRetrieval, version: 2.7.4; rgeos, version: 0.3-26; dplyr, version: 0.7.4; sbtools, version: 1.1.6; httr, version: 1.3.1; rgdal, version: 1.2-16; sp, version: 1.2-6; whisker, version: 0.3-2; yaml, version: 2.1.16; xml2, version: 1.2.0; magrittr, version: 1.5.</native>
+  R packages loaded into this environment: maptools, version: 0.9-2; mda.streams, version: 0.9.24; meddle, version: 0.0.4; maps, version: 3.2.0; dataRetrieval, version: 2.7.4; rgeos, version: 0.3-26; dplyr, version: 0.7.4; sbtools, version: 1.1.6; httr, version: 1.3.1; rgdal, version: 1.2-16; sp, version: 1.2-6; whisker, version: 0.3-2; yaml, version: 2.1.17; xml2, version: 1.2.0; magrittr, version: 1.5.</native>
   </idinfo>
   <dataqual>
     <attracc>

--- a/4_data_release/out/site_points_shapefile.xml
+++ b/4_data_release/out/site_points_shapefile.xml
@@ -29,7 +29,7 @@
       <timeinfo>
         <rngdates>
           <begdate>20071001</begdate>
-          <enddate>12</enddate>
+          <enddate>20170101</enddate>
         </rngdates>
       </timeinfo>
       <current>model estimates</current>

--- a/4_data_release/out/site_points_shapefile.xml
+++ b/4_data_release/out/site_points_shapefile.xml
@@ -29,7 +29,7 @@
       <timeinfo>
         <rngdates>
           <begdate>20071001</begdate>
-          <enddate>dog</enddate>
+          <enddate>20170101</enddate>
         </rngdates>
       </timeinfo>
       <current>model estimates</current>

--- a/4_data_release/out/site_points_shapefile.xml
+++ b/4_data_release/out/site_points_shapefile.xml
@@ -29,7 +29,7 @@
       <timeinfo>
         <rngdates>
           <begdate>20071001</begdate>
-          <enddate>20170101</enddate>
+          <enddate>dog</enddate>
         </rngdates>
       </timeinfo>
       <current>model estimates</current>

--- a/4_data_release/out/site_points_shapefile.xml
+++ b/4_data_release/out/site_points_shapefile.xml
@@ -29,7 +29,7 @@
       <timeinfo>
         <rngdates>
           <begdate>20071001</begdate>
-          <enddate>20170101</enddate>
+          <enddate>12</enddate>
         </rngdates>
       </timeinfo>
       <current>model estimates</current>

--- a/4_data_release/out/site_points_shapefile.xml
+++ b/4_data_release/out/site_points_shapefile.xml
@@ -171,8 +171,9 @@
       <cntinfo>
         <cntperp>
           <cntper>Alison P. Appling</cntper>
-          <cntorg>U.S. Geological Survey<cntpos>Ecologist, Data Science Branch, Integrated Information Dissemination Division, U.S. Geological Survey</cntpos></cntorg>
+          <cntorg>U.S. Geological Survey</cntorg>
         </cntperp>
+        <cntpos>Ecologist</cntpos>
         <cntaddr>
           <addrtype>Mailing and Physical</addrtype>
           <address>520 N Park Ave, Ste 221</address>
@@ -188,7 +189,7 @@
     <datacred>This work was funded by the USGS Powell Center (Working Group title: "Continental-scale overview of stream primary productivity, its links to water quality, and consequences for aquatic carbon biogeochemistry"). Additional financial support came from the USGS NAWQA program and Office of Water Information. NSF grants DEB-1146283 and EF1442501 partially supported ROH. The USGS Wisconsin Modeling Center provided access to the HTCondor cluster for generating metabolism estimates.</datacred>
     <native>This dataset was generated using open source tools available in the R programming language (R version 3.4.1 (2017-06-30)).
   The computing platform for generating data and metadata was x86_64-apple-darwin15.6.0. 
-  R packages loaded into this environment: maptools, version: 0.9-2; mda.streams, version: 0.9.24; meddle, version: 0.0.4; maps, version: 3.2.0; dataRetrieval, version: 2.7.4; rgeos, version: 0.3-26; dplyr, version: 0.7.4; sbtools, version: 1.1.6; httr, version: 1.3.1; rgdal, version: 1.2-16; whisker, version: 0.3-2; yaml, version: 2.1.16; xml2, version: 1.1.1; magrittr, version: 1.5; sp, version: 1.2-6.</native>
+  R packages loaded into this environment: maptools, version: 0.9-2; mda.streams, version: 0.9.24; meddle, version: 0.0.4; maps, version: 3.2.0; dataRetrieval, version: 2.7.4; rgeos, version: 0.3-26; dplyr, version: 0.7.4; sbtools, version: 1.1.6; httr, version: 1.3.1; rgdal, version: 1.2-16; sp, version: 1.2-6; whisker, version: 0.3-2; yaml, version: 2.1.16; xml2, version: 1.2.0; magrittr, version: 1.5.</native>
   </idinfo>
   <dataqual>
     <attracc>
@@ -207,7 +208,7 @@
     <lineage>
       <procstep>
         <procdesc>A points shapefile was created containing locations of the USGS gaging stations included in this data release.  Spatial tools in the R programming language were used to perform the operations of creating the spatial datasets and modifying attributes. </procdesc>
-        <procdate>20180116</procdate>
+        <procdate>20180305</procdate>
       </procstep>
     </lineage>
   </dataqual>
@@ -308,14 +309,14 @@
     </stdorder>
   </distinfo>
   <metainfo>
-    <metd>20180116</metd>
+    <metd>20180305</metd>
     <metc>
       <cntinfo>
         <cntperp>
           <cntper>Jordan S. Read</cntper>
           <cntorg>U.S. Geological Survey</cntorg>
         </cntperp>
-        <cntpos>Chief, Data Science Branch, Integrated Information Dissemination Division, U.S. Geological Survey</cntpos>
+        <cntpos>Research Civil Engineer</cntpos>
         <cntaddr>
           <addrtype>Mailing and Physical</addrtype>
           <address>8551 Research Way #120</address>

--- a/4_data_release/out/site_points_shapefile.xml
+++ b/4_data_release/out/site_points_shapefile.xml
@@ -189,7 +189,7 @@
     <datacred>This work was funded by the USGS Powell Center (Working Group title: "Continental-scale overview of stream primary productivity, its links to water quality, and consequences for aquatic carbon biogeochemistry"). Additional financial support came from the USGS NAWQA program and Office of Water Information. NSF grants DEB-1146283 and EF1442501 partially supported ROH. The USGS Wisconsin Modeling Center provided access to the HTCondor cluster for generating metabolism estimates.</datacred>
     <native>This dataset was generated using open source tools available in the R programming language (R version 3.4.1 (2017-06-30)).
   The computing platform for generating data and metadata was x86_64-apple-darwin15.6.0. 
-  R packages loaded into this environment: maptools, version: 0.9-2; mda.streams, version: 0.9.24; meddle, version: 0.0.4; maps, version: 3.2.0; dataRetrieval, version: 2.7.4; rgeos, version: 0.3-26; dplyr, version: 0.7.4; sbtools, version: 1.1.6; httr, version: 1.3.1; rgdal, version: 1.2-16; sp, version: 1.2-6; whisker, version: 0.3-2; yaml, version: 2.1.16; xml2, version: 1.2.0; magrittr, version: 1.5.</native>
+  R packages loaded into this environment: maptools, version: 0.9-2; mda.streams, version: 0.9.24; meddle, version: 0.0.4; maps, version: 3.2.0; dataRetrieval, version: 2.7.4; rgeos, version: 0.3-26; dplyr, version: 0.7.4; sbtools, version: 1.1.6; httr, version: 1.3.1; rgdal, version: 1.2-16; sp, version: 1.2-6; whisker, version: 0.3-2; yaml, version: 2.1.17; xml2, version: 1.2.0; magrittr, version: 1.5.</native>
   </idinfo>
   <dataqual>
     <attracc>


### PR DESCRIPTION
For #243, but some research for #234 in here too that didn't go anywhere. 

@aappling-usgs a gotcha here: I manually edited the two template.xml files here, which I thought would be OK since they are in `/in/...`. But...when I tried to run 
```r
remake::make('../4_data_release/out/timeseries.xml', remake_file = "4_release_timeseries.yml")
```
to see if I could update the fixes for #234 to those other files, something re-wrote that formatting back into `../4_data_release/in/fgdc_template_ents.xml`. I didn't track down what did that, but it seemed odd, since that file wasn't a target elsewhere. Know why that would happen? 